### PR TITLE
Adding a SemVar.parse(str, format) class method

### DIFF
--- a/lib/semver.rb
+++ b/lib/semver.rb
@@ -110,7 +110,7 @@ class SemVer
     regex_str.gsub! '%M', '(?<major>\d+)'
     regex_str.gsub! '%m', '(?<minor>\d+)'
     regex_str.gsub! '%p', '(?<patch>\d+)'
-    regex_str.gsub! '%s', '(?<special>[A-Za-z][0-9A-Za-z\.]+)?'
+    regex_str.gsub! '%s', '(?:-(?<special>[A-Za-z][0-9A-Za-z\.]+))?'
 
     regex = Regexp.new(regex_str)
     match = regex.match version_string

--- a/spec/semver_spec.rb
+++ b/spec/semver_spec.rb
@@ -71,16 +71,16 @@ describe SemVer do
       '0.10.100-b32',
       'version:3-0-45',
       '3$2^1',
-      '3$2^1&bla567',
+      '3$2^1-bla567',
     ]
 
     formats = [
       nil,
       SemVer::TAG_FORMAT,
-      '%M.%m.%p-%s',
+      '%M.%m.%p%s',
       'version:%M-%m-%p',
       '%M$%m^%p',
-      '%M$%m^%p&%s',
+      '%M$%m^%p%s',
     ]
 
     semvers= [


### PR DESCRIPTION
Add a parse class method to SemVer that parses a SemVer instance from a string and passed format. If the format is omitted, it defaults to SemVer::TAG_FORMAT. By default, the parse still pass if major, minor, or patch isn't found (or omitted from the format), but that can be turned off by passing false for allow_missing.

```
SemVer.parse 'v1.2.3-beta'
SemVer.parse '1-2-3===beta', '%M-%m-%p===%s'
SemVer.parse 'v1.2', 'v%M.%m'
SemVer.parse 'v1.2', 'v%M.%m', false  ===> fails and returns nil
```
