### PR TITLE
 Introduce a `next` command. Mirroring the `inc` but formatting, not saving

### DIFF
--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -31,6 +31,7 @@ inc[rement] major | minor | patch  # increment a specific version number
 pre[release] [STRING]              # set a pre-release version suffix
 spe[cial] [STRING]                 # set a pre-release version suffix (deprecated)
 meta[data] [STRING]                # set a metadata version suffix
+next                               # format incremented specific version without saving it
 format                             # printf like format: %M, %m, %p, %s
 tag                                # equivalent to format 'v%M.%m.%p%s'
 help
@@ -76,6 +77,26 @@ PLEASE READ http://semver.org
       version.save
     end
     
+    command :next do
+      version = SemVer.find
+      dimension = next_param_or_error("required: major | minor | patch")
+      case dimension
+      when 'major'
+        version.major += 1
+        version.minor =  0
+        version.patch =  0
+      when 'minor'
+        version.minor += 1
+        version.patch =  0
+      when 'patch'
+        version.patch += 1
+      else
+        raise CommandError, "#{dimension} is invalid: major | minor | patch"
+      end
+      version.special = ''
+      version.metadata = ''
+      puts version.to_s
+    end
     
     # Set the pre-release of the .semver file.
     command :special, :spe, :prerelease, :pre do

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -57,45 +57,13 @@ PLEASE READ http://semver.org
     
     # Increment the major, minor, or patch of the .semver file.
     command :increment, :inc do
-      version = SemVer.find
       dimension = next_param_or_error("required: major | minor | patch")
-      case dimension
-      when 'major'
-        version.major += 1
-        version.minor =  0
-        version.patch =  0
-      when 'minor'
-        version.minor += 1
-        version.patch =  0
-      when 'patch'
-        version.patch += 1
-      else
-        raise CommandError, "#{dimension} is invalid: major | minor | patch"
-      end
-      version.special = ''
-      version.metadata = ''
-      version.save
+      find_and_increment(dimension).save
     end
     
     command :next do
-      version = SemVer.find
       dimension = next_param_or_error("required: major | minor | patch")
-      case dimension
-      when 'major'
-        version.major += 1
-        version.minor =  0
-        version.patch =  0
-      when 'minor'
-        version.minor += 1
-        version.patch =  0
-      when 'patch'
-        version.patch += 1
-      else
-        raise CommandError, "#{dimension} is invalid: major | minor | patch"
-      end
-      version.special = ''
-      version.metadata = ''
-      puts version.to_s
+      puts find_and_increment(dimension).to_s
     end
     
     # Set the pre-release of the .semver file.
@@ -134,10 +102,29 @@ PLEASE READ http://semver.org
     command :help do
       puts help_text
     end
-    
 
+    private
 
+    def find_and_increment(dimension)
+      version = SemVer.find
+      case dimension
+      when 'major'
+        version.major += 1
+        version.minor =  0
+        version.patch =  0
+      when 'minor'
+        version.minor += 1
+        version.patch =  0
+      when 'patch'
+        version.patch += 1
+      else
+        raise CommandError, "#{dimension} is invalid: major | minor | patch"
+      end
+      version.special = ''
+      version.metadata = ''
 
+      version
+    end
   end
   
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -345,13 +345,9 @@ describe XSemVer::Runner do
     end
 
     describe "without a valid subcommand" do
-      before :each do
-        @invalid_command = 'invalid'
-      end
-
       it "raises an exception" do
         expect {
-          described_class.new command, @invalid_command
+          described_class.new command, 'invalid'
         }.to raise_error(
           XSemVer::Runner::CommandError,
           "#{@invalid_command} is invalid: major | minor | patch"

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -246,7 +246,130 @@ describe XSemVer::Runner do
   end
   
   
-  
+  ###############
+  # SEMVER NEXT #
+  ###############
+  describe 'next' do
+    let(:command) { 'next' }
+    before :each do
+      SemVer.new(5,6,7,'foo','bar').save @test_file
+
+      # does not modify the .semver file
+      expect {
+        begin
+          described_class.new command, @invalid_command
+        rescue
+        end
+      }.to_not change{ File.mtime(@test_file) }
+    end
+
+    describe "major" do
+      before :each do
+        described_class.new command, 'major'
+        @next = SemVer.parse(@output.string)
+      end
+
+      it "increments the major version" do
+        @next.major.should eq(6)
+      end
+
+      it "sets the minor version to 0" do
+        @next.minor.should eq(0)
+      end
+
+      it "sets the patch vesion to 0" do
+        @next.patch.should eq(0)
+      end
+
+      it "sets the prerelease to an empty string" do
+        @next.prerelease.should eq("")
+      end
+
+      it "sets the metadata to an empty string" do
+        @next.metadata.should eq("")
+      end
+    end
+
+    describe "minor" do
+      before :each  do
+        described_class.new command, 'minor'
+        @next = SemVer.parse(@output.string)
+      end
+
+      it "does not change the major version" do
+        @next.major.should eq(5)
+      end
+
+      it "increments the minor version" do
+        @next.minor.should eq(7)
+      end
+
+      it "sets the patch version to 0" do
+        @next.patch.should eq(0)
+      end
+
+      it "sets the prerelease to an empty string" do
+        @next.prerelease.should eq("")
+      end
+
+      it "sets the metadata to an empty string" do
+        @next.metadata.should eq("")
+      end
+    end
+
+    describe "patch" do
+      before :each  do
+        described_class.new command, 'patch'
+        @next = SemVer.parse(@output.string)
+      end
+
+      it "does not change the major version" do
+        @next.major.should eq(5)
+      end
+
+      it "does not change the minor version" do
+        @next.minor.should eq(6)
+      end
+
+      it "increments the patch version" do
+        @next.patch.should eq(8)
+      end
+
+      it "sets the prerelease to an empty string" do
+        @next.prerelease.should eq("")
+      end
+
+      it "sets the metadata to an empty string" do
+        @next.metadata.should eq("")
+      end
+    end
+
+    describe "without a valid subcommand" do
+      before :each do
+        @invalid_command = 'invalid'
+      end
+
+      it "raises an exception" do
+        expect {
+          described_class.new command, @invalid_command
+        }.to raise_error(
+          XSemVer::Runner::CommandError,
+          "#{@invalid_command} is invalid: major | minor | patch"
+        )
+      end
+    end
+
+    describe "without a subcommand" do
+      it "raises an exception" do
+        expect {
+          described_class.new command
+        }.to raise_error(
+          XSemVer::Runner::CommandError,
+          "required: major | minor | patch"
+        )
+      end
+    end
+  end
 
   #######################
   # SEMVER PRE(RELEASE) #


### PR DESCRIPTION
This command increments, but does not persist. Useful for scripting and
integrating.

E.g. When one wants to make a release branch in git, without bumping the
version just yet, one could now say `git branch release/$(semver next)`.

It formats using the `tag`, aka the `to_s` formatting. Additional
formatting is out of scope because it would require even more arguments
passed.

