### PR TITLE
Use require_relative to load files from project

### DIFF
--- a/bin/semver
+++ b/bin/semver
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'runner'
+require_relative '../lib/runner'
 
 begin
   XSemVer::Runner.new(*ARGV)

--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -1,5 +1,5 @@
-require 'semver'
-require 'dsl'
+require_relative 'semver'
+require_relative 'dsl'
 
 module XSemVer
   # Contains the logic for performing SemVer operations from the command line.

--- a/lib/semver.rb
+++ b/lib/semver.rb
@@ -1,6 +1,6 @@
 require 'yaml'
-require 'xsemver'
-require 'semver/semvermissingerror'
+require_relative 'xsemver'
+require_relative 'semver/semvermissingerror'
 
 class SemVer < ::XSemVer::SemVer
 end

--- a/lib/xsemver.rb
+++ b/lib/xsemver.rb
@@ -1,6 +1,6 @@
 require 'yaml'
-require 'semver/semvermissingerror'
-require 'pre_release'
+require_relative 'semver/semvermissingerror'
+require_relative 'pre_release'
 
 module XSemVer
   # sometimes a library that you are using has already put the class


### PR DESCRIPTION
makes it easier (possible) to test new changes when developing changes to this project.
- https://ruby-doc.org/core-2.1.2/Kernel.html#method-i-require_relative

i don't see how this could harm in production, other than perhaps minimum ruby verison bump.

But from stackoverflow I read it's present at least 1.9 and below:
> Before 1.9.2 there was no need for require_relative, because current directory of script was in $:. See stackoverflow.com/questions/2900370 – Nakilon Sep 9 '10 at 20:43

https://stackoverflow.com/questions/3672586/what-is-the-difference-between-require-relative-and-require-in-ruby

but if even ruby 2.3 support has ended, 1.9 should be fine:
- https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/